### PR TITLE
Ignore deleted files

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -130,7 +130,7 @@ apply_clang_formating_to_altered_files(){
 
 commit_hash=$(git log -1 | grep commit | awk '{print $2}')
 
-list_of_changed_header_and_source_files=$(git diff --cached --name-only $commit_hash | grep '.cc\|.h')
+list_of_changed_header_and_source_files=$(git diff --diff-filter=d --cached --name-only $commit_hash | grep '.cc\|.h')
 
 year=$(date +"%Y")
 for file in ${list_of_changed_header_and_source_files[@]}


### PR DESCRIPTION
The problem was, if I deleted files from a repo clang would still try to run on them and throw an error, i.e. I could not commit it. 

This should exempt deleted files from being formatted